### PR TITLE
Use TBB instead of the internal tasking engine.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ set -eux
         -DEMBREE_TUTORIALS=OFF \
         -DEMBREE_ISA_AVX512KNL=OFF \
         -DEMBREE_ISA_AVX512SKX=OFF \
-        -DEMBREE_TASKING_SYSTEM=INTERNAL
+        -DEMBREE_TASKING_SYSTEM=TBB
     make -j install
 )
 
@@ -49,7 +49,7 @@ set -eux
     cmake ../../ospray \
         -DCMAKE_INSTALL_PREFIX=../install \
         -DCMAKE_BUILD_TYPE=Debug \
-        -DOSPRAY_TASKING_SYSTEM=INTERNAL
+        -DOSPRAY_TASKING_SYSTEM=TBB
     make -j install
 )
 


### PR DESCRIPTION
I've never used the internal one and am suspect that it isn't well maintained by ospray/embree devs. In a test build of your test on my system, the Intenal option crashes a large fraction of the times but the TBB build passed 100/100 times on both mac and ubuntu.